### PR TITLE
Enhance link and add color

### DIFF
--- a/Notification/RocketChat.php
+++ b/Notification/RocketChat.php
@@ -79,18 +79,21 @@ class RocketChat extends Base implements NotificationInterface
 
         $message = '*['.$project['name'].']* ';
         $message .= $title;
-        $message .= ' ('.$eventData['task']['title'].')';
 
         if ($this->configModel->get('application_url') !== '') {
-            $message .= ' - <';
-            $message .= $this->helper->url->to('TaskViewController', 'show', array('task_id' => $eventData['task']['id'], 'project_id' => $project['id']), '', true);
-            $message .= '|'.t('view the task on Kanboard').'>';
+            $url = $this->helper->url->to('TaskViewController', 'show', array('task_id' => $eventData['task']['id'], 'project_id' => $project['id']), '', true);
+            $message = preg_replace('/#(\d+)( |$)/', '<'.$url.'|#$1 "'.$eventData['task']['title'].'">$2', $message);
+        }
+        else {
+            $message = preg_replace('/#(\d+)( |$)/', '#$1 "'.$eventData['task']['title'].'"$2', $message);
         }
 
         return array(
-            'text' => $message,
             'username' => 'Kanboard',
             'icon_url' => 'https://kanboard.net/assets/img/favicon.png',
+            'attachments' => array(
+                    array('text' => $message, 'color' => $eventData['task']['color_id'])
+            )
         );
     }
 


### PR DESCRIPTION
This is a proposition for #4 and #5. It:
* Adds link to Kanboard directly to the task number and title (using regex
* Moves message to "attachements", this allows to add a color

It works quite well on my Rocket Chat instance, as you can see below:
![kanboard_rocketchat enhance](https://cloud.githubusercontent.com/assets/953989/22783540/96bbe33a-eecc-11e6-9349-2ed2852011d9.png)

What do you think of this solution?
I would like to add the content of new comments, subtasks or description, but I don't know how to retrieve it easily...


