### PR TITLE
Update the plugin to ver 1.0.7

### DIFF
--- a/Notification/RocketChat.php
+++ b/Notification/RocketChat.php
@@ -24,7 +24,7 @@ class RocketChat extends Base implements NotificationInterface
      */
     public function notifyUser(array $user, $eventName, array $eventData)
     {
-        $webhook = $this->userMetadataModel->get($user['id'], 'rocketchat_webhook_url');
+        $webhook = $this->userMetadataModel->get($user['id'], 'rocketchat_webhook_url', $this->configModel->get('rocketchat_webhook_url'));
         $channel = $this->userMetadataModel->get($user['id'], 'rocketchat_webhook_channel');
 
         if (! empty($webhook)) {
@@ -82,13 +82,16 @@ class RocketChat extends Base implements NotificationInterface
         $message .= ' ('.$eventData['task']['title'].')';
 
         if ($this->configModel->get('application_url') !== '') {
-            $message .= ' - <';
-            $message .= $this->helper->url->to('TaskViewController', 'show', array('task_id' => $eventData['task']['id'], 'project_id' => $project['id']), '', true);
-            $message .= '|'.t('view the task on Kanboard').'>';
+         $message .= ' - ';
+         $message .= '['.t('view the task on Kanboard').']';
+         $message .= '(';
+         $message .= $this->helper->url->to('TaskViewController', 'show', array('task_id' => $eventData['task']['id'], 'project_id' => $project['id']), '', true);
+         $message .= ')';
         }
 
         return array(
             'text' => $message,
+            'username' => 'kanboard',
         );
     }
 
@@ -102,7 +105,7 @@ class RocketChat extends Base implements NotificationInterface
      * @param  string    $eventName
      * @param  array     $eventData
      */
-    private function sendMessage($webhook, $channel, array $project, $eventName, array $eventData)
+    protected function sendMessage($webhook, $channel, array $project, $eventName, array $eventData)
     {
         $payload = $this->getMessage($project, $eventName, $eventData);
         if (! empty($channel)) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -15,6 +15,7 @@ class Plugin extends Base
 {
     public function initialize()
     {
+        $this->template->hook->attach('template:config:integrations', 'RocketChat:config/integration');
         $this->template->hook->attach('template:project:integrations', 'RocketChat:project/integration');
         $this->template->hook->attach('template:user:integrations', 'RocketChat:user/integration');
 
@@ -39,7 +40,7 @@ class Plugin extends Base
 
     public function getPluginVersion()
     {
-        return '1.0.6';
+        return '1.0.7';
     }
 
     public function getPluginHomepage()

--- a/Template/config/integration.php
+++ b/Template/config/integration.php
@@ -1,0 +1,11 @@
+<h3>RocketChat</h3>
+<div class="panel">
+    <?= $this->form->label(t('Webhook URL'), 'rocketchat_webhook_url') ?>
+    <?= $this->form->text('rocketchat_webhook_url', $values) ?>
+
+    <p class="form-help"><a href="https://github.com/kanboard/plugin-rocketchat#configuration" target="_blank"><?= t('Help on RocketChat integration') ?></a></p>
+
+    <div class="form-actions">
+        <input type="submit" value="<?= t('Save') ?>" class="btn btn-blue"/>
+    </div>
+</div>


### PR DESCRIPTION
I'm not a programmer at all, but..
Can we update the plugin so that it won't generate broken links due to changes made for markdown feature in rocket.chat?
So there are changes from 1.0.7 version of Slack plugin and fixes that I saw for rocket.chat plugin from others, everything works fine between my instances, but I could make mistakes easily...